### PR TITLE
Added rewriting for property/event accessors

### DIFF
--- a/RoslynLinqRewrite/RoslynLinqRewrite/LinqRewriter.cs
+++ b/RoslynLinqRewrite/RoslynLinqRewrite/LinqRewriter.cs
@@ -80,13 +80,38 @@ namespace Shaman.Roslyn.LinqRewrite
             if (memberAccess != null)
             {
                 var symbol = semantic.GetSymbolInfo(memberAccess).Symbol as IMethodSymbol;
-                var owner = node.AncestorsAndSelf().FirstOrDefault(x => x is MethodDeclarationSyntax);
-                if (owner == null) return null;
-                currentMethodIsStatic = semantic.GetDeclaredSymbol((MethodDeclarationSyntax)owner).IsStatic;
-                currentMethodName = ((MethodDeclarationSyntax)owner).Identifier.ValueText;
-                currentMethodTypeParameters = ((MethodDeclarationSyntax)owner).TypeParameterList;
-                currentMethodConstraintClauses = ((MethodDeclarationSyntax)owner).ConstraintClauses;
+                var owner = node.AncestorsAndSelf().OfType<MethodDeclarationSyntax>().FirstOrDefault();
+	            if (owner != null)
+				{
+					currentMethodIsStatic = semantic.GetDeclaredSymbol(owner).IsStatic;
+					currentMethodName = owner.Identifier.ValueText;
+					currentMethodTypeParameters = owner.TypeParameterList;
+					currentMethodConstraintClauses = owner.ConstraintClauses;
+					
+	            }
+	            else
+	            {
+					var accessor = node.AncestorsAndSelf().OfType<AccessorDeclarationSyntax>().FirstOrDefault();
+					if (accessor == null) return null;
+		            var parent = accessor.Parent?.Parent;
+					if(parent == null) throw new NotSupportedException("Accessors must be in a property or event block");
+					currentMethodIsStatic = semantic.GetDeclaredSymbol(parent).IsStatic;
+					currentMethodTypeParameters = null;
+					currentMethodConstraintClauses = new SyntaxList<TypeParameterConstraintClauseSyntax>();
 
+					var property = parent as PropertyDeclarationSyntax;
+					if (property != null)
+					{
+						currentMethodName = property.Identifier.ValueText;
+					}
+					else
+					{
+						var ev = parent as EventDeclarationSyntax;
+						if (ev == null)
+							throw new NotSupportedException("Accessors must be in properties or events. Not supported: " + parent);
+						currentMethodName = ev.Identifier.ValueText;
+					}
+				}
           
                 if (IsSupportedMethod(node))
                 {
@@ -302,7 +327,19 @@ namespace Shaman.Roslyn.LinqRewrite
             return k;
         }
 
-        private bool HasNoRewriteAttribute(SyntaxList<AttributeListSyntax> attributeLists)
+	    public override SyntaxNode VisitAccessorDeclaration(AccessorDeclarationSyntax node)
+	    {
+			if (HasNoRewriteAttribute(node.AttributeLists)) return node;
+			var old = RewrittenLinqQueries;
+			var k = base.VisitAccessorDeclaration(node);
+			if (RewrittenLinqQueries != old)
+			{
+				RewrittenMethods++;
+			}
+			return k;
+	    }
+
+	    private bool HasNoRewriteAttribute(SyntaxList<AttributeListSyntax> attributeLists)
         {
             return attributeLists.Any(x => x.Attributes.Any(y =>
             {

--- a/RoslynLinqRewrite/RoslynLinqRewrite/LinqRewriter.cs
+++ b/RoslynLinqRewrite/RoslynLinqRewrite/LinqRewriter.cs
@@ -81,37 +81,37 @@ namespace Shaman.Roslyn.LinqRewrite
             {
                 var symbol = semantic.GetSymbolInfo(memberAccess).Symbol as IMethodSymbol;
                 var owner = node.AncestorsAndSelf().OfType<MethodDeclarationSyntax>().FirstOrDefault();
-	            if (owner != null)
-				{
-					currentMethodIsStatic = semantic.GetDeclaredSymbol(owner).IsStatic;
-					currentMethodName = owner.Identifier.ValueText;
-					currentMethodTypeParameters = owner.TypeParameterList;
-					currentMethodConstraintClauses = owner.ConstraintClauses;
-					
-	            }
-	            else
-	            {
-					var accessor = node.AncestorsAndSelf().OfType<AccessorDeclarationSyntax>().FirstOrDefault();
-					if (accessor == null) return null;
-		            var parent = accessor.Parent?.Parent;
-					if(parent == null) throw new NotSupportedException("Accessors must be in a property or event block");
-					currentMethodIsStatic = semantic.GetDeclaredSymbol(parent).IsStatic;
-					currentMethodTypeParameters = null;
-					currentMethodConstraintClauses = new SyntaxList<TypeParameterConstraintClauseSyntax>();
+                if (owner != null)
+                {
+                    currentMethodIsStatic = semantic.GetDeclaredSymbol(owner).IsStatic;
+                    currentMethodName = owner.Identifier.ValueText;
+                    currentMethodTypeParameters = owner.TypeParameterList;
+                    currentMethodConstraintClauses = owner.ConstraintClauses;
+                    
+                }
+                else
+                {
+                    var accessor = node.AncestorsAndSelf().OfType<AccessorDeclarationSyntax>().FirstOrDefault();
+                    if (accessor == null) return null;
+                    var parent = accessor.Parent?.Parent;
+                    if(parent == null) throw new NotSupportedException("Accessors must be in a property or event block");
+                    currentMethodIsStatic = semantic.GetDeclaredSymbol(parent).IsStatic;
+                    currentMethodTypeParameters = null;
+                    currentMethodConstraintClauses = new SyntaxList<TypeParameterConstraintClauseSyntax>();
 
-					var property = parent as PropertyDeclarationSyntax;
-					if (property != null)
-					{
-						currentMethodName = property.Identifier.ValueText;
-					}
-					else
-					{
-						var ev = parent as EventDeclarationSyntax;
-						if (ev == null)
-							throw new NotSupportedException("Accessors must be in properties or events. Not supported: " + parent);
-						currentMethodName = ev.Identifier.ValueText;
-					}
-				}
+                    var property = parent as PropertyDeclarationSyntax;
+                    if (property != null)
+                    {
+                        currentMethodName = property.Identifier.ValueText;
+                    }
+                    else
+                    {
+                        var ev = parent as EventDeclarationSyntax;
+                        if (ev == null)
+                            throw new NotSupportedException("Accessors must be in properties or events. Not supported: " + parent);
+                        currentMethodName = ev.Identifier.ValueText;
+                    }
+                }
           
                 if (IsSupportedMethod(node))
                 {
@@ -327,19 +327,19 @@ namespace Shaman.Roslyn.LinqRewrite
             return k;
         }
 
-	    public override SyntaxNode VisitAccessorDeclaration(AccessorDeclarationSyntax node)
-	    {
-			if (HasNoRewriteAttribute(node.AttributeLists)) return node;
-			var old = RewrittenLinqQueries;
-			var k = base.VisitAccessorDeclaration(node);
-			if (RewrittenLinqQueries != old)
-			{
-				RewrittenMethods++;
-			}
-			return k;
-	    }
+        public override SyntaxNode VisitAccessorDeclaration(AccessorDeclarationSyntax node)
+        {
+            if (HasNoRewriteAttribute(node.AttributeLists)) return node;
+            var old = RewrittenLinqQueries;
+            var k = base.VisitAccessorDeclaration(node);
+            if (RewrittenLinqQueries != old)
+            {
+                RewrittenMethods++;
+            }
+            return k;
+        }
 
-	    private bool HasNoRewriteAttribute(SyntaxList<AttributeListSyntax> attributeLists)
+        private bool HasNoRewriteAttribute(SyntaxList<AttributeListSyntax> attributeLists)
         {
             return attributeLists.Any(x => x.Attributes.Any(y =>
             {


### PR DESCRIPTION
This just enables the rewrite pass for accessors as well as methods, saving the need to wrap any LINQ in a method before it will be optimised. I don't believe there are any adverse effects as a result.
